### PR TITLE
Update gradle actions to latest 4.x release

### DIFF
--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -10,5 +10,5 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4.1.7
-      - uses: gradle/actions/wrapper-validation@v3.4.2
-      - uses: gradle/actions/dependency-submission@v3.4.2
+      - uses: gradle/actions/wrapper-validation@v4.1.0
+      - uses: gradle/actions/dependency-submission@v4.1.0

--- a/.github/workflows/update-gradle-wrapper.yml
+++ b/.github/workflows/update-gradle-wrapper.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4.1.7
-      - uses: gradle/actions/setup-gradle@v3.4.2
+      - uses: gradle/actions/setup-gradle@v4.1.0
         with:
           cache-read-only: true
       - uses: gradle-update/update-gradle-wrapper-action@v1.0.20

--- a/.github/workflows/verification.yml
+++ b/.github/workflows/verification.yml
@@ -13,7 +13,6 @@ jobs:
     runs-on: [ "ubuntu-latest" ]
     steps:
       - uses: actions/checkout@v4.1.7
-      - uses: gradle/actions/wrapper-validation@v3.4.2
-      - uses: gradle/actions/setup-gradle@v3.4.2
+      - uses: gradle/actions/setup-gradle@v4.1.0
       - name: "Run all verifications"
         run: "./gradlew check"


### PR DESCRIPTION
Since 4.x the wrapper validation is automatically included when using `setup-gradle`.